### PR TITLE
Various API tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -105,7 +105,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -343,9 +343,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "electrum_streaming_client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -773,15 +773,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex-conservative"
@@ -884,7 +878,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -903,9 +897,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -970,13 +964,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1001,11 +995,11 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1032,9 +1026,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1042,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1107,15 +1101,15 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1195,7 +1189,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1224,7 +1218,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1237,7 +1231,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -1268,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1401,9 +1395,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1471,9 +1465,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1760,7 +1754,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrum_streaming_client"
-version = "0.2.0"
+version = "0.3.0"
 description = "Experimental but sane electrum client by @evanlinjin."
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bitcoin = { version = "0.32", features = ["serde"] }
 
-tokio = { version = "1.44.2", optional = true }
+tokio = { version = "1.44.2", features = ["io-util"],  optional = true }
 tokio-util = { version = "0.7.15", features = ["compat"], optional = true }
 
 [features]

--- a/src/io.rs
+++ b/src/io.rs
@@ -202,3 +202,18 @@ where
     b.push(b'\n');
     writer.write_all(&b).await
 }
+
+/// Asynchronously writes a JSON-RPC request or batch to a tokio async writer, followed by a newline.
+///
+/// This is the `"tokio"` version of [`async_write`].
+#[cfg(feature = "tokio")]
+pub async fn tokio_write<W, T>(mut writer: W, msg: T) -> std::io::Result<()>
+where
+    T: Into<MaybeBatch<RawRequest>>,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+    let mut b = serde_json::to_vec(&msg.into()).expect("must serialize");
+    b.push(b'\n');
+    writer.write_all(&b).await
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -46,7 +46,7 @@ pub trait Request: Clone {
 /// server methods.
 ///
 /// The response is returned as a generic `serde_json::Value`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Custom {
     /// The JSON-RPC method name to call.
     pub method: CowStr,
@@ -103,7 +103,7 @@ impl<SendError: std::error::Error> std::error::Error for Error<SendError> {}
 /// without downloading intermediate headers—use [`HeaderWithProof`] instead.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-block-header>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Header {
     /// The height of the block to fetch.
     pub height: u32,
@@ -132,7 +132,7 @@ impl Request for Header {
 /// If no proof is required, consider using the [`Header`] type instead.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-block-header>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HeaderWithProof {
     /// The height of the block whose header is being requested.
     pub height: u32,
@@ -161,7 +161,7 @@ impl Request for HeaderWithProof {
 /// period).
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-block-headers>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Headers {
     /// The height of the first block header to fetch.
     pub start_height: u32,
@@ -191,7 +191,7 @@ impl Request for Headers {
 /// Most Electrum servers cap the maximum `count` at 2016 headers per request.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-block-headers>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HeadersWithCheckpoint {
     /// The height of the first block header to fetch.
     pub start_height: u32,
@@ -224,7 +224,7 @@ impl Request for HeadersWithCheckpoint {
 /// fee rate (in BTC per kilobyte) required to be included within the specified number of blocks.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-estimatefee>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EstimateFee {
     /// The number of blocks to target for confirmation.
     pub number: usize,
@@ -244,7 +244,7 @@ impl Request for EstimateFee {
 /// the server will push a notification whenever a new block is added to the chain tip.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-headers-subscribe>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HeadersSubscribe;
 
 impl Request for HeadersSubscribe {
@@ -261,7 +261,7 @@ impl Request for HeadersSubscribe {
 /// fee rate (in BTC per kilobyte) that the server will accept for relaying transactions.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-relayfee>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RelayFee;
 
 impl Request for RelayFee {
@@ -279,7 +279,7 @@ impl Request for RelayFee {
 /// transactions) for the provided script hash.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-balance>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetBalance {
     /// The script hash to query.
     pub script_hash: ElectrumScriptHash,
@@ -314,7 +314,7 @@ impl Request for GetBalance {
 /// does not include unconfirmed transactions.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetHistory {
     /// The script hash whose history should be fetched.
     pub script_hash: ElectrumScriptHash,
@@ -345,7 +345,7 @@ impl Request for GetHistory {
 /// Resource request for `blockchain.scripthash.get_mempool`.
 ///
 /// Note that `electrs` does not support this endpoint.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetMempool {
     pub script_hash: ElectrumScriptHash,
 }
@@ -380,7 +380,7 @@ impl Request for GetMempool {
 /// value, height, and outpoint.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-listunspent>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ListUnspent {
     /// The script hash to query.
     pub script_hash: ElectrumScriptHash,
@@ -415,7 +415,7 @@ impl Request for ListUnspent {
 /// a new transaction is confirmed or enters the mempool.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-subscribe>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ScriptHashSubscribe {
     /// The script hash to subscribe to.
     pub script_hash: ElectrumScriptHash,
@@ -444,13 +444,13 @@ impl Request for ScriptHashSubscribe {
     }
 }
 
-#[derive(Debug, Clone)]
 /// A request to cancel a previous subscription to a script hash.
 ///
 /// This corresponds to the `"blockchain.scripthash.unsubscribe"` Electrum RPC method. It tells the
 /// server to stop sending notifications related to the specified script hash.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-unsubscribe>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ScriptHashUnsubscribe {
     /// The script hash to unsubscribe from.
     pub script_hash: ElectrumScriptHash,
@@ -485,7 +485,7 @@ impl Request for ScriptHashUnsubscribe {
 /// the given transaction to the Electrum server's mempool.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-broadcast>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BroadcastTx(pub bitcoin::Transaction);
 
 impl Request for BroadcastTx {
@@ -501,13 +501,13 @@ impl Request for BroadcastTx {
     }
 }
 
-#[derive(Debug, Clone)]
 /// A request for the raw transaction corresponding to a given transaction ID.
 ///
 /// This corresponds to the `"blockchain.transaction.get"` Electrum RPC method. It returns the full
 /// transaction as a serialized hex string, typically used to inspect, rebroadcast, or verify it.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-get>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetTx {
     /// The transaction ID to fetch.
     pub txid: Txid,
@@ -530,7 +530,7 @@ impl Request for GetTx {
 /// the Merkle branch proving that the transaction is included in the block at the specified height.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-get-merkle>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetTxMerkle {
     /// The transaction ID to verify.
     pub txid: Txid,
@@ -558,7 +558,7 @@ impl Request for GetTxMerkle {
 /// This can be used for enumerating all transactions in a block by querying sequential positions.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-id-from-pos>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetTxidFromPos {
     /// The height of the block containing the transaction.
     pub height: u32,
@@ -585,7 +585,7 @@ impl Request for GetTxidFromPos {
 /// allowing clients to estimate the mempool's fee landscape.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#mempool-get-fee-histogram>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GetFeeHistogram;
 
 impl Request for GetFeeHistogram {
@@ -602,7 +602,7 @@ impl Request for GetFeeHistogram {
 /// banner string, often used to display terms of service or notices to the user.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-banner>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Banner;
 
 impl Request for Banner {
@@ -619,7 +619,7 @@ impl Request for Banner {
 /// `null`. It's used to keep the connection alive or measure basic liveness.
 ///
 /// See: <https://electrum-protocol.readthedocs.io/en/latest/protocol-methods.html#server-ping>
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Ping;
 
 impl Request for Ping {

--- a/src/response.rs
+++ b/src/response.rs
@@ -140,6 +140,20 @@ impl Tx {
             Tx::Confirmed(ConfirmedTx { height, .. }) => Some(*height),
         }
     }
+
+    /// Returns the transaction height as represented by the Electrum API.
+    ///
+    /// * Confirmed transactions have a height > 0.
+    /// * Unconfirmed transactions either have a height of 0 or -1.
+    ///   * 0 means transaction inputs are all confirmed.
+    ///   * -1 means not all transaction inputs are confirmed.
+    pub fn electrum_height(&self) -> i64 {
+        match self {
+            Tx::Mempool(mempool_tx) if mempool_tx.confirmed_inputs => 0,
+            Tx::Mempool(_) => -1,
+            Tx::Confirmed(confirmed_tx) => confirmed_tx.height.to_consensus_u32() as i64,
+        }
+    }
 }
 
 /// A confirmed transaction entry returned by `"blockchain.scripthash.get_history"`.


### PR DESCRIPTION
* Added `ElectrumScriptStatus::from_history`
* Added `io::tokio_write` to write to `tokio::io::AsyncWrite`
* Derived `PartialEq, Eq, Hash` on request types
* Added `Tx::electrum_height`
* Changed `State` to track `next_id` externally. This increases flexibility of the API.